### PR TITLE
Fix urlencoded path

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "Advanced CoffeeScript Support for VSCode",
   "author": "Yucheng Chuang",
   "license": "MIT",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "yorkxin",
   "repository": {
     "type": "git",

--- a/server/src/utils/fileReader.ts
+++ b/server/src/utils/fileReader.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs'
-import * as URL from 'url'
+import Uri from 'vscode-uri'
 
 export function uriToPath(uri: string): string {
-  return URL.parse(uri).path
+  // This decodes url-encoded chars such as `@` or `:` (used in Windows)
+  return Uri.parse(uri).fsPath
 }
 
 export function readFileByPath(path: string): string {


### PR DESCRIPTION
Fixes #1 

- Make this extension work on Windows.

## Beta version

https://github.com/chitsaou/vscode-coffeescript-support/releases/tag/v0.1.3beta1