### PR TITLE
Support Dynamic Import syntax

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Unreleased
 
-Security Update on test libraries and `vscode` package.
+Features:
+
+- Supports Dynamic Import syntax `import()`
+
+Others:
+
+- Security Update on test libraries and `vscode` package.
 
 # 0.2.0
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -460,9 +460,9 @@
       }
     },
     "@types/node": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
-      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
+      "version": "11.13.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.6.tgz",
+      "integrity": "sha512-Xoo/EBzEe8HxTSwaZNLZjaW6M6tA/+GmD3/DZ6uo8qSaolE/9Oarko0oV1fVfrLqOz0tx0nXJB4rdD5c+vixLw=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -644,7 +644,7 @@
     },
     "async": {
       "version": "0.2.10",
-      "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
     "async-limiter": {
@@ -1028,25 +1028,25 @@
       "dev": true
     },
     "coffeescript": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.4.0.tgz",
-      "integrity": "sha512-VIAMBUX0vrQwCr9nSbQ63G1j0Ys8wGZg5x5jXRcRodm6b07TIFLaVe1QvPS9Qk/m1uwPcAZn8kJMf4aXhScBxQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.4.1.tgz",
+      "integrity": "sha512-34GV1aHrsMpTaO3KfMJL40ZNuvKDR/g98THHnE9bQj8HjMaZvSrLik99WWqyMhRtbe8V5hpx5iLgdcSvM/S2wg=="
     },
     "coffeescript-lsp-core": {
-      "version": "github:chitsaou/coffeescript-lsp-core#53568c7f6af575c1da287263c35c846196588bec",
-      "from": "github:chitsaou/coffeescript-lsp-core#v1.2.0",
+      "version": "github:chitsaou/coffeescript-lsp-core#ad2d4a39fb8dd11169934d75cfabba3be0fa965f",
+      "from": "github:chitsaou/coffeescript-lsp-core#v1.3.0",
       "requires": {
         "@types/nedb": "^1.8.5",
         "coffeescript": "^2.1.0",
-        "coffeescript-types": "git+https://github.com/chitsaou/coffeescript-types.git#0ddb8532a16ebb83de2634fb8ac5c9521b8a72b8",
+        "coffeescript-types": "git+https://github.com/chitsaou/coffeescript-types.git#a160c74ced80f77cd9cb79633317a1df6adb6b03",
         "commander": "^2.15.1",
         "nedb": "^1.8.0",
         "vscode-languageserver": "^5.0.3"
       }
     },
     "coffeescript-types": {
-      "version": "git+https://github.com/chitsaou/coffeescript-types.git#0ddb8532a16ebb83de2634fb8ac5c9521b8a72b8",
-      "from": "git+https://github.com/chitsaou/coffeescript-types.git"
+      "version": "git+https://github.com/chitsaou/coffeescript-types.git#a160c74ced80f77cd9cb79633317a1df6adb6b03",
+      "from": "git+https://github.com/chitsaou/coffeescript-types.git#v1.0.1"
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1083,9 +1083,9 @@
       }
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "compare-versions": {
       "version": "3.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/chitsaou/vscode-coffeescript-support"
   },
   "dependencies": {
-    "coffeescript-lsp-core": "chitsaou/coffeescript-lsp-core#v1.2.0",
+    "coffeescript-lsp-core": "chitsaou/coffeescript-lsp-core#v1.3.0",
     "tmp": "0.0.33",
     "vscode-languageserver": "^5.0.0"
   },


### PR DESCRIPTION
Supports a new syntax in CoffeeScript 2.4.0 https://github.com/jashkenas/coffeescript/pull/5182

```coffee
Lodash = import('lodash')
```

Related: 

- https://github.com/chitsaou/coffeescript-lsp-core/pull/6 - symbols mapping
- https://github.com/chitsaou/coffeescript-types/commit/4b668a01771c35672d4e90088189372c5cabce2b - type declaration

Closes https://github.com/chitsaou/vscode-coffeescript-support/issues/12

## Checklist

- [x] `client/CHANGELOG.md`
